### PR TITLE
Tacky Bug Fix

### DIFF
--- a/library/Strive/Internal/TH.hs
+++ b/library/Strive/Internal/TH.hs
@@ -24,7 +24,13 @@ underscore = concatMap go
     else [c]
 
 dropPrefix :: String -> String
-dropPrefix = drop 1 . dropWhile (/= '_')
+dropPrefix s =
+  let unprefixed = (drop 1 . dropWhile (/= '_')) s
+  in case unprefixed of
+    "type" -> "stype"
+    "data" -> "sdata"
+    _      -> unprefixed
+
 
 -- | Generate lens classes and instances for a type.
 makeLenses :: String -> Q [Dec]


### PR DESCRIPTION
"data" and "type" are reserved words in newer versions of GHC. This causes trouble at compile time. Now use stype and sdata instead of type and data for lenses.

I'm not sure if there is a better solution.