### PR TITLE
Change athlete in token response to summary

### DIFF
--- a/library/Strive/Types/Authentication.hs
+++ b/library/Strive/Types/Authentication.hs
@@ -9,12 +9,12 @@ module Strive.Types.Authentication
 import Data.Aeson.TH (deriveFromJSON)
 import Data.Text (Text)
 import Strive.Internal.TH (options)
-import Strive.Types.Athletes (AthleteDetailed)
+import Strive.Types.Athletes (AthleteSummary)
 
 -- | <http://strava.github.io/api/v3/oauth/#example-response>
 data TokenExchangeResponse = TokenExchangeResponse
   { tokenExchangeResponse_accessToken :: Text
-  , tokenExchangeResponse_athlete     :: AthleteDetailed
+  , tokenExchangeResponse_athlete     :: AthleteSummary
   } deriving Show
 
 $(deriveFromJSON options ''TokenExchangeResponse)


### PR DESCRIPTION
This fixes #107. 

This change was mentioned in Strava's change log: https://strava.github.io/api/v3/changelog/

> July 24, 2017 Replace athlete detail with athlete summary on OAuth token exchange. 