### PR TITLE
Stop using `data-default`

### DIFF
--- a/source/library/Strive/Internal/Options.hs
+++ b/source/library/Strive/Internal/Options.hs
@@ -1,10 +1,10 @@
 -- | Common options that apply to many endpoints.
 module Strive.Internal.Options
   ( PaginationOptions (..),
+    defaultPaginationOptions,
   )
 where
 
-import Data.Default (Default, def)
 import Network.HTTP.Types (QueryLike, toQuery)
 
 -- | Options for paginating.
@@ -14,12 +14,12 @@ data PaginationOptions = PaginationOptions
   }
   deriving (Show)
 
-instance Default PaginationOptions where
-  def =
-    PaginationOptions
-      { paginationOptions_page = 1,
-        paginationOptions_perPage = 200
-      }
+defaultPaginationOptions :: PaginationOptions
+defaultPaginationOptions =
+  PaginationOptions
+    { paginationOptions_page = 1,
+      paginationOptions_perPage = 200
+    }
 
 instance QueryLike PaginationOptions where
   toQuery options =

--- a/source/library/Strive/Internal/Options.hs
+++ b/source/library/Strive/Internal/Options.hs
@@ -1,29 +1,36 @@
 -- | Common options that apply to many endpoints.
 module Strive.Internal.Options
   ( PaginationOptions (..),
-    defaultPaginationOptions,
   )
 where
 
+import qualified Data.Semigroup as Semigroup
 import Network.HTTP.Types (QueryLike, toQuery)
 
 -- | Options for paginating.
 data PaginationOptions = PaginationOptions
-  { paginationOptions_page :: Integer,
-    paginationOptions_perPage :: Integer
+  { paginationOptions_page :: Semigroup.Last Integer,
+    paginationOptions_perPage :: Semigroup.Last Integer
   }
   deriving (Show)
 
-defaultPaginationOptions :: PaginationOptions
-defaultPaginationOptions =
-  PaginationOptions
-    { paginationOptions_page = 1,
-      paginationOptions_perPage = 200
-    }
+instance Semigroup PaginationOptions where
+  x <> y =
+    PaginationOptions
+      { paginationOptions_page = paginationOptions_page x <> paginationOptions_page y,
+        paginationOptions_perPage = paginationOptions_perPage x <> paginationOptions_perPage y
+      }
+
+instance Monoid PaginationOptions where
+  mempty =
+    PaginationOptions
+      { paginationOptions_page = pure 1,
+        paginationOptions_perPage = pure 200
+      }
 
 instance QueryLike PaginationOptions where
   toQuery options =
     toQuery
-      [ ("page", show (paginationOptions_page options)),
-        ("per_page", show (paginationOptions_perPage options))
+      [ ("page", show (Semigroup.getLast (paginationOptions_page options))),
+        ("per_page", show (Semigroup.getLast (paginationOptions_perPage options)))
       ]

--- a/source/library/Strive/Options/Activities.hs
+++ b/source/library/Strive/Options/Activities.hs
@@ -1,9 +1,13 @@
 -- | 'Strive.Actions.Activities'
 module Strive.Options.Activities
   ( CreateActivityOptions (..),
+    defaultCreateActivityOptions,
     GetActivityOptions (..),
+    defaultGetActivityOptions,
     UpdateActivityOptions (..),
+    defaultUpdateActivityOptions,
     GetCurrentActivitiesOptions (..),
+    defaultGetCurrentActivitiesOptions,
     GetRelatedActivitiesOptions,
     GetFeedOptions,
   )
@@ -12,7 +16,6 @@ where
 import Data.Aeson (encode)
 import Data.ByteString.Char8 (unpack)
 import Data.ByteString.Lazy (toStrict)
-import Data.Default (Default, def)
 import Data.Time.Clock (UTCTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Network.HTTP.Types (QueryLike, toQuery)
@@ -26,12 +29,12 @@ data CreateActivityOptions = CreateActivityOptions
   }
   deriving (Show)
 
-instance Default CreateActivityOptions where
-  def =
-    CreateActivityOptions
-      { createActivityOptions_description = Nothing,
-        createActivityOptions_distance = Nothing
-      }
+defaultCreateActivityOptions :: CreateActivityOptions
+defaultCreateActivityOptions =
+  CreateActivityOptions
+    { createActivityOptions_description = Nothing,
+      createActivityOptions_distance = Nothing
+    }
 
 instance QueryLike CreateActivityOptions where
   toQuery options =
@@ -46,8 +49,8 @@ newtype GetActivityOptions = GetActivityOptions
   }
   deriving (Show)
 
-instance Default GetActivityOptions where
-  def = GetActivityOptions {getActivityOptions_allEfforts = False}
+defaultGetActivityOptions :: GetActivityOptions
+defaultGetActivityOptions = GetActivityOptions {getActivityOptions_allEfforts = False}
 
 instance QueryLike GetActivityOptions where
   toQuery options =
@@ -69,17 +72,17 @@ data UpdateActivityOptions = UpdateActivityOptions
   }
   deriving (Show)
 
-instance Default UpdateActivityOptions where
-  def =
-    UpdateActivityOptions
-      { updateActivityOptions_name = Nothing,
-        updateActivityOptions_type = Nothing,
-        updateActivityOptions_private = Nothing,
-        updateActivityOptions_commute = Nothing,
-        updateActivityOptions_trainer = Nothing,
-        updateActivityOptions_gearId = Nothing,
-        updateActivityOptions_description = Nothing
-      }
+defaultUpdateActivityOptions :: UpdateActivityOptions
+defaultUpdateActivityOptions =
+  UpdateActivityOptions
+    { updateActivityOptions_name = Nothing,
+      updateActivityOptions_type = Nothing,
+      updateActivityOptions_private = Nothing,
+      updateActivityOptions_commute = Nothing,
+      updateActivityOptions_trainer = Nothing,
+      updateActivityOptions_gearId = Nothing,
+      updateActivityOptions_description = Nothing
+    }
 
 instance QueryLike UpdateActivityOptions where
   toQuery options =
@@ -114,14 +117,14 @@ data GetCurrentActivitiesOptions = GetCurrentActivitiesOptions
   }
   deriving (Show)
 
-instance Default GetCurrentActivitiesOptions where
-  def =
-    GetCurrentActivitiesOptions
-      { getCurrentActivitiesOptions_before = Nothing,
-        getCurrentActivitiesOptions_after = Nothing,
-        getCurrentActivitiesOptions_page = 1,
-        getCurrentActivitiesOptions_perPage = 200
-      }
+defaultGetCurrentActivitiesOptions :: GetCurrentActivitiesOptions
+defaultGetCurrentActivitiesOptions =
+  GetCurrentActivitiesOptions
+    { getCurrentActivitiesOptions_before = Nothing,
+      getCurrentActivitiesOptions_after = Nothing,
+      getCurrentActivitiesOptions_page = 1,
+      getCurrentActivitiesOptions_perPage = 200
+    }
 
 instance QueryLike GetCurrentActivitiesOptions where
   toQuery options =

--- a/source/library/Strive/Options/Athletes.hs
+++ b/source/library/Strive/Options/Athletes.hs
@@ -1,43 +1,53 @@
 -- | 'Strive.Actions.Athletes'
 module Strive.Options.Athletes
   ( UpdateCurrentAthleteOptions (..),
-    defaultUpdateCurrentAthleteOptions,
     GetAthleteCrsOptions,
   )
 where
 
+import qualified Data.Monoid as Monoid
 import Network.HTTP.Types (QueryLike, toQuery)
 import Strive.Enums (Gender)
 import Strive.Internal.Options (PaginationOptions)
 
 -- | 'Strive.Actions.updateCurrentAthlete'
 data UpdateCurrentAthleteOptions = UpdateCurrentAthleteOptions
-  { updateCurrentAthleteOptions_city :: Maybe String,
-    updateCurrentAthleteOptions_state :: Maybe String,
-    updateCurrentAthleteOptions_country :: Maybe String,
-    updateCurrentAthleteOptions_sex :: Maybe Gender,
-    updateCurrentAthleteOptions_weight :: Maybe Double
+  { updateCurrentAthleteOptions_city :: Monoid.Last String,
+    updateCurrentAthleteOptions_state :: Monoid.Last String,
+    updateCurrentAthleteOptions_country :: Monoid.Last String,
+    updateCurrentAthleteOptions_sex :: Monoid.Last Gender,
+    updateCurrentAthleteOptions_weight :: Monoid.Last Double
   }
   deriving (Show)
 
-defaultUpdateCurrentAthleteOptions :: UpdateCurrentAthleteOptions
-defaultUpdateCurrentAthleteOptions =
-  UpdateCurrentAthleteOptions
-    { updateCurrentAthleteOptions_city = Nothing,
-      updateCurrentAthleteOptions_state = Nothing,
-      updateCurrentAthleteOptions_country = Nothing,
-      updateCurrentAthleteOptions_sex = Nothing,
-      updateCurrentAthleteOptions_weight = Nothing
-    }
+instance Semigroup UpdateCurrentAthleteOptions where
+  x <> y =
+    UpdateCurrentAthleteOptions
+      { updateCurrentAthleteOptions_city = updateCurrentAthleteOptions_city x <> updateCurrentAthleteOptions_city y,
+        updateCurrentAthleteOptions_state = updateCurrentAthleteOptions_state x <> updateCurrentAthleteOptions_state y,
+        updateCurrentAthleteOptions_country = updateCurrentAthleteOptions_country x <> updateCurrentAthleteOptions_country y,
+        updateCurrentAthleteOptions_sex = updateCurrentAthleteOptions_sex x <> updateCurrentAthleteOptions_sex y,
+        updateCurrentAthleteOptions_weight = updateCurrentAthleteOptions_weight x <> updateCurrentAthleteOptions_weight y
+      }
+
+instance Monoid UpdateCurrentAthleteOptions where
+  mempty =
+    UpdateCurrentAthleteOptions
+      { updateCurrentAthleteOptions_city = mempty,
+        updateCurrentAthleteOptions_state = mempty,
+        updateCurrentAthleteOptions_country = mempty,
+        updateCurrentAthleteOptions_sex = mempty,
+        updateCurrentAthleteOptions_weight = mempty
+      }
 
 instance QueryLike UpdateCurrentAthleteOptions where
   toQuery options =
     toQuery
-      [ ("city", updateCurrentAthleteOptions_city options),
-        ("state", updateCurrentAthleteOptions_state options),
-        ("country", updateCurrentAthleteOptions_country options),
-        ("sex", fmap show (updateCurrentAthleteOptions_sex options)),
-        ("weight", fmap show (updateCurrentAthleteOptions_weight options))
+      [ ("city", Monoid.getLast (updateCurrentAthleteOptions_city options)),
+        ("state", Monoid.getLast (updateCurrentAthleteOptions_state options)),
+        ("country", Monoid.getLast (updateCurrentAthleteOptions_country options)),
+        ("sex", fmap show (Monoid.getLast (updateCurrentAthleteOptions_sex options))),
+        ("weight", fmap show (Monoid.getLast (updateCurrentAthleteOptions_weight options)))
       ]
 
 -- | 'Strive.Actions.getAthleteCrs'

--- a/source/library/Strive/Options/Athletes.hs
+++ b/source/library/Strive/Options/Athletes.hs
@@ -1,11 +1,11 @@
 -- | 'Strive.Actions.Athletes'
 module Strive.Options.Athletes
   ( UpdateCurrentAthleteOptions (..),
+    defaultUpdateCurrentAthleteOptions,
     GetAthleteCrsOptions,
   )
 where
 
-import Data.Default (Default, def)
 import Network.HTTP.Types (QueryLike, toQuery)
 import Strive.Enums (Gender)
 import Strive.Internal.Options (PaginationOptions)
@@ -20,15 +20,15 @@ data UpdateCurrentAthleteOptions = UpdateCurrentAthleteOptions
   }
   deriving (Show)
 
-instance Default UpdateCurrentAthleteOptions where
-  def =
-    UpdateCurrentAthleteOptions
-      { updateCurrentAthleteOptions_city = Nothing,
-        updateCurrentAthleteOptions_state = Nothing,
-        updateCurrentAthleteOptions_country = Nothing,
-        updateCurrentAthleteOptions_sex = Nothing,
-        updateCurrentAthleteOptions_weight = Nothing
-      }
+defaultUpdateCurrentAthleteOptions :: UpdateCurrentAthleteOptions
+defaultUpdateCurrentAthleteOptions =
+  UpdateCurrentAthleteOptions
+    { updateCurrentAthleteOptions_city = Nothing,
+      updateCurrentAthleteOptions_state = Nothing,
+      updateCurrentAthleteOptions_country = Nothing,
+      updateCurrentAthleteOptions_sex = Nothing,
+      updateCurrentAthleteOptions_weight = Nothing
+    }
 
 instance QueryLike UpdateCurrentAthleteOptions where
   toQuery options =

--- a/source/library/Strive/Options/Authentication.hs
+++ b/source/library/Strive/Options/Authentication.hs
@@ -1,13 +1,13 @@
 -- | 'Strive.Actions.Authentication'
 module Strive.Options.Authentication
   ( BuildAuthorizeUrlOptions (..),
+    defaultBuildAuthorizeUrlOptions,
   )
 where
 
 import Data.Aeson (encode)
 import Data.ByteString.Char8 (unpack)
 import Data.ByteString.Lazy (toStrict)
-import Data.Default (Default, def)
 import Data.List (intercalate)
 import Data.Maybe (catMaybes)
 import Network.HTTP.Types (QueryLike, toQuery)
@@ -21,14 +21,14 @@ data BuildAuthorizeUrlOptions = BuildAuthorizeUrlOptions
   }
   deriving (Show)
 
-instance Default BuildAuthorizeUrlOptions where
-  def =
-    BuildAuthorizeUrlOptions
-      { buildAuthorizeUrlOptions_approvalPrompt = False,
-        buildAuthorizeUrlOptions_privateScope = False,
-        buildAuthorizeUrlOptions_writeScope = False,
-        buildAuthorizeUrlOptions_state = ""
-      }
+defaultBuildAuthorizeUrlOptions :: BuildAuthorizeUrlOptions
+defaultBuildAuthorizeUrlOptions =
+  BuildAuthorizeUrlOptions
+    { buildAuthorizeUrlOptions_approvalPrompt = False,
+      buildAuthorizeUrlOptions_privateScope = False,
+      buildAuthorizeUrlOptions_writeScope = False,
+      buildAuthorizeUrlOptions_state = ""
+    }
 
 instance QueryLike BuildAuthorizeUrlOptions where
   toQuery options =

--- a/source/library/Strive/Options/Authentication.hs
+++ b/source/library/Strive/Options/Authentication.hs
@@ -1,7 +1,6 @@
 -- | 'Strive.Actions.Authentication'
 module Strive.Options.Authentication
   ( BuildAuthorizeUrlOptions (..),
-    defaultBuildAuthorizeUrlOptions,
   )
 where
 
@@ -10,25 +9,35 @@ import Data.ByteString.Char8 (unpack)
 import Data.ByteString.Lazy (toStrict)
 import Data.List (intercalate)
 import Data.Maybe (catMaybes)
+import qualified Data.Semigroup as Semigroup
 import Network.HTTP.Types (QueryLike, toQuery)
 
 -- | 'Strive.Actions.buildAuthorizeUrl'
 data BuildAuthorizeUrlOptions = BuildAuthorizeUrlOptions
-  { buildAuthorizeUrlOptions_approvalPrompt :: Bool,
-    buildAuthorizeUrlOptions_privateScope :: Bool,
-    buildAuthorizeUrlOptions_writeScope :: Bool,
-    buildAuthorizeUrlOptions_state :: String
+  { buildAuthorizeUrlOptions_approvalPrompt :: Semigroup.Last Bool,
+    buildAuthorizeUrlOptions_privateScope :: Semigroup.Last Bool,
+    buildAuthorizeUrlOptions_writeScope :: Semigroup.Last Bool,
+    buildAuthorizeUrlOptions_state :: Semigroup.Last String
   }
   deriving (Show)
 
-defaultBuildAuthorizeUrlOptions :: BuildAuthorizeUrlOptions
-defaultBuildAuthorizeUrlOptions =
-  BuildAuthorizeUrlOptions
-    { buildAuthorizeUrlOptions_approvalPrompt = False,
-      buildAuthorizeUrlOptions_privateScope = False,
-      buildAuthorizeUrlOptions_writeScope = False,
-      buildAuthorizeUrlOptions_state = ""
-    }
+instance Semigroup BuildAuthorizeUrlOptions where
+  x <> y =
+    BuildAuthorizeUrlOptions
+      { buildAuthorizeUrlOptions_approvalPrompt = buildAuthorizeUrlOptions_approvalPrompt x <> buildAuthorizeUrlOptions_approvalPrompt y,
+        buildAuthorizeUrlOptions_privateScope = buildAuthorizeUrlOptions_privateScope x <> buildAuthorizeUrlOptions_privateScope y,
+        buildAuthorizeUrlOptions_writeScope = buildAuthorizeUrlOptions_writeScope x <> buildAuthorizeUrlOptions_writeScope y,
+        buildAuthorizeUrlOptions_state = buildAuthorizeUrlOptions_state x <> buildAuthorizeUrlOptions_state y
+      }
+
+instance Monoid BuildAuthorizeUrlOptions where
+  mempty =
+    BuildAuthorizeUrlOptions
+      { buildAuthorizeUrlOptions_approvalPrompt = pure False,
+        buildAuthorizeUrlOptions_privateScope = pure False,
+        buildAuthorizeUrlOptions_writeScope = pure False,
+        buildAuthorizeUrlOptions_state = pure ""
+      }
 
 instance QueryLike BuildAuthorizeUrlOptions where
   toQuery options =
@@ -36,19 +45,19 @@ instance QueryLike BuildAuthorizeUrlOptions where
       [ ( "approval_prompt",
           unpack
             ( toStrict
-                (encode (buildAuthorizeUrlOptions_approvalPrompt options))
+                (encode (Semigroup.getLast (buildAuthorizeUrlOptions_approvalPrompt options)))
             )
         ),
-        ("state", buildAuthorizeUrlOptions_state options)
+        ("state", Semigroup.getLast (buildAuthorizeUrlOptions_state options))
       ]
         <> if null scopes then [] else [("scope", intercalate "," scopes)]
     where
       scopes =
         catMaybes
-          [ if buildAuthorizeUrlOptions_privateScope options
+          [ if Semigroup.getLast (buildAuthorizeUrlOptions_privateScope options)
               then Just "view_private"
               else Nothing,
-            if buildAuthorizeUrlOptions_writeScope options
+            if Semigroup.getLast (buildAuthorizeUrlOptions_writeScope options)
               then Just "write"
               else Nothing
           ]

--- a/source/library/Strive/Options/Clubs.hs
+++ b/source/library/Strive/Options/Clubs.hs
@@ -2,10 +2,10 @@
 module Strive.Options.Clubs
   ( GetClubMembersOptions,
     GetClubActivitiesOptions (..),
+    defaultGetClubActivitiesOptions,
   )
 where
 
-import Data.Default (Default, def)
 import Data.Time.Clock (UTCTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Network.HTTP.Types (QueryLike, toQuery)
@@ -23,14 +23,14 @@ data GetClubActivitiesOptions = GetClubActivitiesOptions
   }
   deriving (Show)
 
-instance Default GetClubActivitiesOptions where
-  def =
-    GetClubActivitiesOptions
-      { getClubActivitiesOptions_before = Nothing,
-        getClubActivitiesOptions_after = Nothing,
-        getClubActivitiesOptions_page = 1,
-        getClubActivitiesOptions_perPage = 200
-      }
+defaultGetClubActivitiesOptions :: GetClubActivitiesOptions
+defaultGetClubActivitiesOptions =
+  GetClubActivitiesOptions
+    { getClubActivitiesOptions_before = Nothing,
+      getClubActivitiesOptions_after = Nothing,
+      getClubActivitiesOptions_page = 1,
+      getClubActivitiesOptions_perPage = 200
+    }
 
 instance QueryLike GetClubActivitiesOptions where
   toQuery options =

--- a/source/library/Strive/Options/Comments.hs
+++ b/source/library/Strive/Options/Comments.hs
@@ -1,38 +1,46 @@
 -- | 'Strive.Actions.Comments'
 module Strive.Options.Comments
   ( GetActivityCommentsOptions (..),
-    defaultGetActivityCommentsOptions,
   )
 where
 
 import Data.Aeson (encode)
 import Data.ByteString.Char8 (unpack)
 import Data.ByteString.Lazy (toStrict)
+import qualified Data.Semigroup as Semigroup
 import Network.HTTP.Types (QueryLike, toQuery)
 
 -- | 'Strive.Actions.getActivityComments'
 data GetActivityCommentsOptions = GetActivityCommentsOptions
-  { getActivityCommentsOptions_markdown :: Bool,
-    getActivityCommentsOptions_page :: Integer,
-    getActivityCommentsOptions_perPage :: Integer
+  { getActivityCommentsOptions_markdown :: Semigroup.Last Bool,
+    getActivityCommentsOptions_page :: Semigroup.Last Integer,
+    getActivityCommentsOptions_perPage :: Semigroup.Last Integer
   }
   deriving (Show)
 
-defaultGetActivityCommentsOptions :: GetActivityCommentsOptions
-defaultGetActivityCommentsOptions =
-  GetActivityCommentsOptions
-    { getActivityCommentsOptions_markdown = False,
-      getActivityCommentsOptions_page = 1,
-      getActivityCommentsOptions_perPage = 200
-    }
+instance Semigroup GetActivityCommentsOptions where
+  x <> y =
+    GetActivityCommentsOptions
+      { getActivityCommentsOptions_markdown = getActivityCommentsOptions_markdown x <> getActivityCommentsOptions_markdown y,
+        getActivityCommentsOptions_page = getActivityCommentsOptions_page x <> getActivityCommentsOptions_page y,
+        getActivityCommentsOptions_perPage = getActivityCommentsOptions_perPage x <> getActivityCommentsOptions_perPage y
+      }
+
+instance Monoid GetActivityCommentsOptions where
+  mempty =
+    GetActivityCommentsOptions
+      { getActivityCommentsOptions_markdown = pure False,
+        getActivityCommentsOptions_page = pure 1,
+        getActivityCommentsOptions_perPage = pure 200
+      }
 
 instance QueryLike GetActivityCommentsOptions where
   toQuery options =
     toQuery
       [ ( "before",
           unpack
-            (toStrict (encode (getActivityCommentsOptions_markdown options)))
+            (toStrict (encode (Semigroup.getLast (getActivityCommentsOptions_markdown options))))
         ),
-        ("page", show (getActivityCommentsOptions_page options)),
-        ("per_page", show (getActivityCommentsOptions_perPage options))
+        ("page", show (Semigroup.getLast (getActivityCommentsOptions_page options))),
+        ("per_page", show (Semigroup.getLast (getActivityCommentsOptions_perPage options)))
       ]

--- a/source/library/Strive/Options/Comments.hs
+++ b/source/library/Strive/Options/Comments.hs
@@ -1,13 +1,13 @@
 -- | 'Strive.Actions.Comments'
 module Strive.Options.Comments
   ( GetActivityCommentsOptions (..),
+    defaultGetActivityCommentsOptions,
   )
 where
 
 import Data.Aeson (encode)
 import Data.ByteString.Char8 (unpack)
 import Data.ByteString.Lazy (toStrict)
-import Data.Default (Default, def)
 import Network.HTTP.Types (QueryLike, toQuery)
 
 -- | 'Strive.Actions.getActivityComments'
@@ -18,13 +18,13 @@ data GetActivityCommentsOptions = GetActivityCommentsOptions
   }
   deriving (Show)
 
-instance Default GetActivityCommentsOptions where
-  def =
-    GetActivityCommentsOptions
-      { getActivityCommentsOptions_markdown = False,
-        getActivityCommentsOptions_page = 1,
-        getActivityCommentsOptions_perPage = 200
-      }
+defaultGetActivityCommentsOptions :: GetActivityCommentsOptions
+defaultGetActivityCommentsOptions =
+  GetActivityCommentsOptions
+    { getActivityCommentsOptions_markdown = False,
+      getActivityCommentsOptions_page = 1,
+      getActivityCommentsOptions_perPage = 200
+    }
 
 instance QueryLike GetActivityCommentsOptions where
   toQuery options =

--- a/source/library/Strive/Options/Segments.hs
+++ b/source/library/Strive/Options/Segments.hs
@@ -2,17 +2,16 @@
 module Strive.Options.Segments
   ( GetStarredSegmentsOptions,
     GetSegmentEffortsOptions (..),
-    defaultGetSegmentEffortsOptions,
     GetSegmentLeaderboardOptions (..),
-    defaultGetSegmentLeaderboardOptions,
     ExploreSegmentsOptions (..),
-    defaultExploreSegmentsOptions,
   )
 where
 
 import Data.Aeson (encode)
 import Data.ByteString.Char8 (unpack)
 import Data.ByteString.Lazy (toStrict)
+import qualified Data.Monoid as Monoid
+import qualified Data.Semigroup as Semigroup
 import Data.Time.Clock (UTCTime)
 import Network.HTTP.Types (QueryLike, toQuery)
 import Strive.Enums
@@ -28,110 +27,141 @@ type GetStarredSegmentsOptions = PaginationOptions
 
 -- | 'Strive.Actions.getSegmentEfforts'
 data GetSegmentEffortsOptions = GetSegmentEffortsOptions
-  { getSegmentEffortsOptions_athleteId :: Maybe Integer,
-    getSegmentEffortsOptions_range :: Maybe (UTCTime, UTCTime),
-    getSegmentEffortsOptions_page :: Integer,
-    getSegmentEffortsOptions_perPage :: Integer
+  { getSegmentEffortsOptions_athleteId :: Monoid.Last Integer,
+    getSegmentEffortsOptions_range :: Monoid.Last (UTCTime, UTCTime),
+    getSegmentEffortsOptions_page :: Semigroup.Last Integer,
+    getSegmentEffortsOptions_perPage :: Semigroup.Last Integer
   }
   deriving (Show)
 
-defaultGetSegmentEffortsOptions :: GetSegmentEffortsOptions
-defaultGetSegmentEffortsOptions =
-  GetSegmentEffortsOptions
-    { getSegmentEffortsOptions_athleteId = Nothing,
-      getSegmentEffortsOptions_range = Nothing,
-      getSegmentEffortsOptions_page = 1,
-      getSegmentEffortsOptions_perPage = 200
-    }
+instance Semigroup GetSegmentEffortsOptions where
+  x <> y =
+    GetSegmentEffortsOptions
+      { getSegmentEffortsOptions_athleteId = getSegmentEffortsOptions_athleteId x <> getSegmentEffortsOptions_athleteId y,
+        getSegmentEffortsOptions_range = getSegmentEffortsOptions_range x <> getSegmentEffortsOptions_range y,
+        getSegmentEffortsOptions_page = getSegmentEffortsOptions_page x <> getSegmentEffortsOptions_page y,
+        getSegmentEffortsOptions_perPage = getSegmentEffortsOptions_perPage x <> getSegmentEffortsOptions_perPage y
+      }
+
+instance Monoid GetSegmentEffortsOptions where
+  mempty =
+    GetSegmentEffortsOptions
+      { getSegmentEffortsOptions_athleteId = mempty,
+        getSegmentEffortsOptions_range = mempty,
+        getSegmentEffortsOptions_page = pure 1,
+        getSegmentEffortsOptions_perPage = pure 200
+      }
 
 instance QueryLike GetSegmentEffortsOptions where
   toQuery options =
     toQuery
-      [ ("athlete_id", fmap show (getSegmentEffortsOptions_athleteId options)),
+      [ ("athlete_id", fmap show (Monoid.getLast (getSegmentEffortsOptions_athleteId options))),
         ( "start_date_local",
           fmap
             (unpack . toStrict . encode . fst)
-            (getSegmentEffortsOptions_range options)
+            (Monoid.getLast (getSegmentEffortsOptions_range options))
         ),
         ( "end_date_local",
           fmap
             (unpack . toStrict . encode . snd)
-            (getSegmentEffortsOptions_range options)
+            (Monoid.getLast (getSegmentEffortsOptions_range options))
         ),
-        ("page", Just (show (getSegmentEffortsOptions_page options))),
-        ("per_page", Just (show (getSegmentEffortsOptions_perPage options)))
+        ("page", Just (show (Semigroup.getLast (getSegmentEffortsOptions_page options)))),
+        ("per_page", Just (show (Semigroup.getLast (getSegmentEffortsOptions_perPage options))))
       ]
 
 -- | 'Strive.Actions.getSegmentLeaderboard'
 data GetSegmentLeaderboardOptions = GetSegmentLeaderboardOptions
-  { getSegmentLeaderboardOptions_gender :: Maybe Gender,
-    getSegmentLeaderboardOptions_ageGroup :: Maybe AgeGroup,
-    getSegmentLeaderboardOptions_weightClass :: Maybe WeightClass,
-    getSegmentLeaderboardOptions_following :: Maybe Bool,
-    getSegmentLeaderboardOptions_clubId :: Maybe Integer,
-    getSegmentLeaderboardOptions_dateRange :: Maybe String,
-    getSegmentLeaderboardOptions_contextEntries :: Maybe Integer,
-    getSegmentLeaderboardOptions_page :: Integer,
-    getSegmentLeaderboardOptions_perPage :: Integer
+  { getSegmentLeaderboardOptions_gender :: Monoid.Last Gender,
+    getSegmentLeaderboardOptions_ageGroup :: Monoid.Last AgeGroup,
+    getSegmentLeaderboardOptions_weightClass :: Monoid.Last WeightClass,
+    getSegmentLeaderboardOptions_following :: Monoid.Last Bool,
+    getSegmentLeaderboardOptions_clubId :: Monoid.Last Integer,
+    getSegmentLeaderboardOptions_dateRange :: Monoid.Last String,
+    getSegmentLeaderboardOptions_contextEntries :: Monoid.Last Integer,
+    getSegmentLeaderboardOptions_page :: Semigroup.Last Integer,
+    getSegmentLeaderboardOptions_perPage :: Semigroup.Last Integer
   }
   deriving (Show)
 
-defaultGetSegmentLeaderboardOptions :: GetSegmentLeaderboardOptions
-defaultGetSegmentLeaderboardOptions =
-  GetSegmentLeaderboardOptions
-    { getSegmentLeaderboardOptions_gender = Nothing,
-      getSegmentLeaderboardOptions_ageGroup = Nothing,
-      getSegmentLeaderboardOptions_weightClass = Nothing,
-      getSegmentLeaderboardOptions_following = Nothing,
-      getSegmentLeaderboardOptions_clubId = Nothing,
-      getSegmentLeaderboardOptions_dateRange = Nothing,
-      getSegmentLeaderboardOptions_contextEntries = Nothing,
-      getSegmentLeaderboardOptions_page = 1,
-      getSegmentLeaderboardOptions_perPage = 200
-    }
+instance Semigroup GetSegmentLeaderboardOptions where
+  x <> y =
+    GetSegmentLeaderboardOptions
+      { getSegmentLeaderboardOptions_gender = getSegmentLeaderboardOptions_gender x <> getSegmentLeaderboardOptions_gender y,
+        getSegmentLeaderboardOptions_ageGroup = getSegmentLeaderboardOptions_ageGroup x <> getSegmentLeaderboardOptions_ageGroup y,
+        getSegmentLeaderboardOptions_weightClass = getSegmentLeaderboardOptions_weightClass x <> getSegmentLeaderboardOptions_weightClass y,
+        getSegmentLeaderboardOptions_following = getSegmentLeaderboardOptions_following x <> getSegmentLeaderboardOptions_following y,
+        getSegmentLeaderboardOptions_clubId = getSegmentLeaderboardOptions_clubId x <> getSegmentLeaderboardOptions_clubId y,
+        getSegmentLeaderboardOptions_dateRange = getSegmentLeaderboardOptions_dateRange x <> getSegmentLeaderboardOptions_dateRange y,
+        getSegmentLeaderboardOptions_contextEntries = getSegmentLeaderboardOptions_contextEntries x <> getSegmentLeaderboardOptions_contextEntries y,
+        getSegmentLeaderboardOptions_page = getSegmentLeaderboardOptions_page x <> getSegmentLeaderboardOptions_page y,
+        getSegmentLeaderboardOptions_perPage = getSegmentLeaderboardOptions_perPage x <> getSegmentLeaderboardOptions_perPage y
+      }
+
+instance Monoid GetSegmentLeaderboardOptions where
+  mempty =
+    GetSegmentLeaderboardOptions
+      { getSegmentLeaderboardOptions_gender = mempty,
+        getSegmentLeaderboardOptions_ageGroup = mempty,
+        getSegmentLeaderboardOptions_weightClass = mempty,
+        getSegmentLeaderboardOptions_following = mempty,
+        getSegmentLeaderboardOptions_clubId = mempty,
+        getSegmentLeaderboardOptions_dateRange = mempty,
+        getSegmentLeaderboardOptions_contextEntries = mempty,
+        getSegmentLeaderboardOptions_page = pure 1,
+        getSegmentLeaderboardOptions_perPage = pure 200
+      }
 
 instance QueryLike GetSegmentLeaderboardOptions where
   toQuery options =
     toQuery
-      [ ("gender", fmap show (getSegmentLeaderboardOptions_gender options)),
-        ("age_group", fmap show (getSegmentLeaderboardOptions_ageGroup options)),
+      [ ("gender", fmap show (Monoid.getLast (getSegmentLeaderboardOptions_gender options))),
+        ("age_group", fmap show (Monoid.getLast (getSegmentLeaderboardOptions_ageGroup options))),
         ( "weight_class",
-          fmap show (getSegmentLeaderboardOptions_weightClass options)
+          fmap show (Monoid.getLast (getSegmentLeaderboardOptions_weightClass options))
         ),
         ( "following",
           fmap
             (unpack . toStrict . encode)
-            (getSegmentLeaderboardOptions_following options)
+            (Monoid.getLast (getSegmentLeaderboardOptions_following options))
         ),
-        ("club_id", fmap show (getSegmentLeaderboardOptions_clubId options)),
-        ("date_range", getSegmentLeaderboardOptions_dateRange options),
+        ("club_id", fmap show (Monoid.getLast (getSegmentLeaderboardOptions_clubId options))),
+        ("date_range", Monoid.getLast (getSegmentLeaderboardOptions_dateRange options)),
         ( "context_entries",
-          fmap show (getSegmentLeaderboardOptions_contextEntries options)
+          fmap show (Monoid.getLast (getSegmentLeaderboardOptions_contextEntries options))
         ),
-        ("page", Just (show (getSegmentLeaderboardOptions_page options))),
-        ("per_page", Just (show (getSegmentLeaderboardOptions_perPage options)))
+        ("page", Just (show (Semigroup.getLast (getSegmentLeaderboardOptions_page options)))),
+        ("per_page", Just (show (Semigroup.getLast (getSegmentLeaderboardOptions_perPage options))))
       ]
 
 -- | 'Strive.Actions.exploreSegments'
 data ExploreSegmentsOptions = ExploreSegmentsOptions
-  { exploreSegmentsOptions_activityType :: SegmentActivityType,
-    exploreSegmentsOptions_minCat :: Integer,
-    exploreSegmentsOptions_maxCat :: Integer
+  { exploreSegmentsOptions_activityType :: Semigroup.Last SegmentActivityType,
+    exploreSegmentsOptions_minCat :: Semigroup.Last Integer,
+    exploreSegmentsOptions_maxCat :: Semigroup.Last Integer
   }
   deriving (Show)
 
-defaultExploreSegmentsOptions :: ExploreSegmentsOptions
-defaultExploreSegmentsOptions =
-  ExploreSegmentsOptions
-    { exploreSegmentsOptions_activityType = Riding,
-      exploreSegmentsOptions_minCat = 0,
-      exploreSegmentsOptions_maxCat = 5
-    }
+instance Semigroup ExploreSegmentsOptions where
+  x <> y =
+    ExploreSegmentsOptions
+      { exploreSegmentsOptions_activityType = exploreSegmentsOptions_activityType x <> exploreSegmentsOptions_activityType y,
+        exploreSegmentsOptions_minCat = exploreSegmentsOptions_minCat x <> exploreSegmentsOptions_minCat y,
+        exploreSegmentsOptions_maxCat = exploreSegmentsOptions_maxCat x <> exploreSegmentsOptions_maxCat y
+      }
+
+instance Monoid ExploreSegmentsOptions where
+  mempty =
+    ExploreSegmentsOptions
+      { exploreSegmentsOptions_activityType = pure Riding,
+        exploreSegmentsOptions_minCat = pure 0,
+        exploreSegmentsOptions_maxCat = pure 5
+      }
 
 instance QueryLike ExploreSegmentsOptions where
   toQuery options =
     toQuery
-      [ ("activity_type", show (exploreSegmentsOptions_activityType options)),
-        ("min_cat", show (exploreSegmentsOptions_minCat options)),
-        ("max_cat", show (exploreSegmentsOptions_maxCat options))
+      [ ("activity_type", show (Semigroup.getLast (exploreSegmentsOptions_activityType options))),
+        ("min_cat", show (Semigroup.getLast (exploreSegmentsOptions_minCat options))),
+        ("max_cat", show (Semigroup.getLast (exploreSegmentsOptions_maxCat options)))
       ]

--- a/source/library/Strive/Options/Segments.hs
+++ b/source/library/Strive/Options/Segments.hs
@@ -2,15 +2,17 @@
 module Strive.Options.Segments
   ( GetStarredSegmentsOptions,
     GetSegmentEffortsOptions (..),
+    defaultGetSegmentEffortsOptions,
     GetSegmentLeaderboardOptions (..),
+    defaultGetSegmentLeaderboardOptions,
     ExploreSegmentsOptions (..),
+    defaultExploreSegmentsOptions,
   )
 where
 
 import Data.Aeson (encode)
 import Data.ByteString.Char8 (unpack)
 import Data.ByteString.Lazy (toStrict)
-import Data.Default (Default, def)
 import Data.Time.Clock (UTCTime)
 import Network.HTTP.Types (QueryLike, toQuery)
 import Strive.Enums
@@ -33,14 +35,14 @@ data GetSegmentEffortsOptions = GetSegmentEffortsOptions
   }
   deriving (Show)
 
-instance Default GetSegmentEffortsOptions where
-  def =
-    GetSegmentEffortsOptions
-      { getSegmentEffortsOptions_athleteId = Nothing,
-        getSegmentEffortsOptions_range = Nothing,
-        getSegmentEffortsOptions_page = 1,
-        getSegmentEffortsOptions_perPage = 200
-      }
+defaultGetSegmentEffortsOptions :: GetSegmentEffortsOptions
+defaultGetSegmentEffortsOptions =
+  GetSegmentEffortsOptions
+    { getSegmentEffortsOptions_athleteId = Nothing,
+      getSegmentEffortsOptions_range = Nothing,
+      getSegmentEffortsOptions_page = 1,
+      getSegmentEffortsOptions_perPage = 200
+    }
 
 instance QueryLike GetSegmentEffortsOptions where
   toQuery options =
@@ -74,19 +76,19 @@ data GetSegmentLeaderboardOptions = GetSegmentLeaderboardOptions
   }
   deriving (Show)
 
-instance Default GetSegmentLeaderboardOptions where
-  def =
-    GetSegmentLeaderboardOptions
-      { getSegmentLeaderboardOptions_gender = Nothing,
-        getSegmentLeaderboardOptions_ageGroup = Nothing,
-        getSegmentLeaderboardOptions_weightClass = Nothing,
-        getSegmentLeaderboardOptions_following = Nothing,
-        getSegmentLeaderboardOptions_clubId = Nothing,
-        getSegmentLeaderboardOptions_dateRange = Nothing,
-        getSegmentLeaderboardOptions_contextEntries = Nothing,
-        getSegmentLeaderboardOptions_page = 1,
-        getSegmentLeaderboardOptions_perPage = 200
-      }
+defaultGetSegmentLeaderboardOptions :: GetSegmentLeaderboardOptions
+defaultGetSegmentLeaderboardOptions =
+  GetSegmentLeaderboardOptions
+    { getSegmentLeaderboardOptions_gender = Nothing,
+      getSegmentLeaderboardOptions_ageGroup = Nothing,
+      getSegmentLeaderboardOptions_weightClass = Nothing,
+      getSegmentLeaderboardOptions_following = Nothing,
+      getSegmentLeaderboardOptions_clubId = Nothing,
+      getSegmentLeaderboardOptions_dateRange = Nothing,
+      getSegmentLeaderboardOptions_contextEntries = Nothing,
+      getSegmentLeaderboardOptions_page = 1,
+      getSegmentLeaderboardOptions_perPage = 200
+    }
 
 instance QueryLike GetSegmentLeaderboardOptions where
   toQuery options =
@@ -118,13 +120,13 @@ data ExploreSegmentsOptions = ExploreSegmentsOptions
   }
   deriving (Show)
 
-instance Default ExploreSegmentsOptions where
-  def =
-    ExploreSegmentsOptions
-      { exploreSegmentsOptions_activityType = Riding,
-        exploreSegmentsOptions_minCat = 0,
-        exploreSegmentsOptions_maxCat = 5
-      }
+defaultExploreSegmentsOptions :: ExploreSegmentsOptions
+defaultExploreSegmentsOptions =
+  ExploreSegmentsOptions
+    { exploreSegmentsOptions_activityType = Riding,
+      exploreSegmentsOptions_minCat = 0,
+      exploreSegmentsOptions_maxCat = 5
+    }
 
 instance QueryLike ExploreSegmentsOptions where
   toQuery options =

--- a/source/library/Strive/Options/Streams.hs
+++ b/source/library/Strive/Options/Streams.hs
@@ -1,10 +1,10 @@
 -- | 'Strive.Actions.Streams'
 module Strive.Options.Streams
   ( GetStreamsOptions (..),
+    defaultGetStreamsOptions,
   )
 where
 
-import Data.Default (Default, def)
 import Network.HTTP.Types (QueryLike, toQuery)
 import Strive.Enums (Resolution, SeriesType (Distance))
 
@@ -15,12 +15,12 @@ data GetStreamsOptions = GetStreamsOptions
   }
   deriving (Show)
 
-instance Default GetStreamsOptions where
-  def =
-    GetStreamsOptions
-      { getStreamsOptions_resolution = Nothing,
-        getStreamsOptions_seriesType = Distance
-      }
+defaultGetStreamsOptions :: GetStreamsOptions
+defaultGetStreamsOptions =
+  GetStreamsOptions
+    { getStreamsOptions_resolution = Nothing,
+      getStreamsOptions_seriesType = Distance
+    }
 
 instance QueryLike GetStreamsOptions where
   toQuery options =

--- a/source/library/Strive/Options/Streams.hs
+++ b/source/library/Strive/Options/Streams.hs
@@ -1,30 +1,38 @@
 -- | 'Strive.Actions.Streams'
 module Strive.Options.Streams
   ( GetStreamsOptions (..),
-    defaultGetStreamsOptions,
   )
 where
 
+import qualified Data.Monoid as Monoid
+import qualified Data.Semigroup as Semigroup
 import Network.HTTP.Types (QueryLike, toQuery)
 import Strive.Enums (Resolution, SeriesType (Distance))
 
 -- | 'Strive.Actions.getStreams'
 data GetStreamsOptions = GetStreamsOptions
-  { getStreamsOptions_resolution :: Maybe Resolution,
-    getStreamsOptions_seriesType :: SeriesType
+  { getStreamsOptions_resolution :: Monoid.Last Resolution,
+    getStreamsOptions_seriesType :: Semigroup.Last SeriesType
   }
   deriving (Show)
 
-defaultGetStreamsOptions :: GetStreamsOptions
-defaultGetStreamsOptions =
-  GetStreamsOptions
-    { getStreamsOptions_resolution = Nothing,
-      getStreamsOptions_seriesType = Distance
-    }
+instance Semigroup GetStreamsOptions where
+  x <> y =
+    GetStreamsOptions
+      { getStreamsOptions_resolution = getStreamsOptions_resolution x <> getStreamsOptions_resolution y,
+        getStreamsOptions_seriesType = getStreamsOptions_seriesType x <> getStreamsOptions_seriesType y
+      }
+
+instance Monoid GetStreamsOptions where
+  mempty =
+    GetStreamsOptions
+      { getStreamsOptions_resolution = mempty,
+        getStreamsOptions_seriesType = pure Distance
+      }
 
 instance QueryLike GetStreamsOptions where
   toQuery options =
     toQuery
-      [ ("resolution", fmap show (getStreamsOptions_resolution options)),
-        ("series_type", Just (show (getStreamsOptions_seriesType options)))
+      [ ("resolution", fmap show (Monoid.getLast (getStreamsOptions_resolution options))),
+        ("series_type", Just (show (Semigroup.getLast (getStreamsOptions_seriesType options))))
       ]

--- a/source/library/Strive/Options/Uploads.hs
+++ b/source/library/Strive/Options/Uploads.hs
@@ -1,46 +1,58 @@
 -- | 'Strive.Actions.Uploads'
 module Strive.Options.Uploads
   ( UploadActivityOptions (..),
-    defaultUploadActivityOptions,
   )
 where
 
+import qualified Data.Monoid as Monoid
+import qualified Data.Semigroup as Semigroup
 import Network.HTTP.Types (QueryLike, toQuery)
 import Strive.Enums (ActivityType)
 
 -- | 'Strive.Actions.uploadActivity'
 data UploadActivityOptions = UploadActivityOptions
-  { uploadActivityOptions_activityType :: Maybe ActivityType,
-    uploadActivityOptions_name :: Maybe String,
-    uploadActivityOptions_description :: Maybe String,
-    uploadActivityOptions_private :: Bool,
-    uploadActivityOptions_trainer :: Bool,
-    uploadActivityOptions_externalId :: Maybe String
+  { uploadActivityOptions_activityType :: Monoid.Last ActivityType,
+    uploadActivityOptions_name :: Monoid.Last String,
+    uploadActivityOptions_description :: Monoid.Last String,
+    uploadActivityOptions_private :: Semigroup.Last Bool,
+    uploadActivityOptions_trainer :: Semigroup.Last Bool,
+    uploadActivityOptions_externalId :: Monoid.Last String
   }
   deriving (Show)
 
-defaultUploadActivityOptions :: UploadActivityOptions
-defaultUploadActivityOptions =
-  UploadActivityOptions
-    { uploadActivityOptions_activityType = Nothing,
-      uploadActivityOptions_name = Nothing,
-      uploadActivityOptions_description = Nothing,
-      uploadActivityOptions_private = False,
-      uploadActivityOptions_trainer = False,
-      uploadActivityOptions_externalId = Nothing
-    }
+instance Semigroup.Semigroup UploadActivityOptions where
+  x <> y =
+    UploadActivityOptions
+      { uploadActivityOptions_activityType = uploadActivityOptions_activityType x <> uploadActivityOptions_activityType y,
+        uploadActivityOptions_name = uploadActivityOptions_name x <> uploadActivityOptions_name y,
+        uploadActivityOptions_description = uploadActivityOptions_description x <> uploadActivityOptions_description y,
+        uploadActivityOptions_private = uploadActivityOptions_private x <> uploadActivityOptions_private y,
+        uploadActivityOptions_trainer = uploadActivityOptions_trainer x <> uploadActivityOptions_trainer y,
+        uploadActivityOptions_externalId = uploadActivityOptions_externalId x <> uploadActivityOptions_externalId y
+      }
+
+instance Monoid.Monoid UploadActivityOptions where
+  mempty =
+    UploadActivityOptions
+      { uploadActivityOptions_activityType = mempty,
+        uploadActivityOptions_name = mempty,
+        uploadActivityOptions_description = mempty,
+        uploadActivityOptions_private = pure False,
+        uploadActivityOptions_trainer = pure False,
+        uploadActivityOptions_externalId = mempty
+      }
 
 instance QueryLike UploadActivityOptions where
   toQuery options =
     toQuery
-      [ ("activity_type", fmap show (uploadActivityOptions_activityType options)),
-        ("name", uploadActivityOptions_name options),
-        ("description", uploadActivityOptions_description options),
+      [ ("activity_type", fmap show (Monoid.getLast (uploadActivityOptions_activityType options))),
+        ("name", Monoid.getLast (uploadActivityOptions_name options)),
+        ("description", Monoid.getLast (uploadActivityOptions_description options)),
         ( "private",
-          Just (show (fromEnum (uploadActivityOptions_private options)))
+          Just (show (fromEnum (Semigroup.getLast (uploadActivityOptions_private options))))
         ),
         ( "trainer",
-          Just (show (fromEnum (uploadActivityOptions_trainer options)))
+          Just (show (fromEnum (Semigroup.getLast (uploadActivityOptions_trainer options))))
         ),
-        ("external_id", uploadActivityOptions_externalId options)
+        ("external_id", Monoid.getLast (uploadActivityOptions_externalId options))
       ]

--- a/source/library/Strive/Options/Uploads.hs
+++ b/source/library/Strive/Options/Uploads.hs
@@ -1,10 +1,10 @@
 -- | 'Strive.Actions.Uploads'
 module Strive.Options.Uploads
   ( UploadActivityOptions (..),
+    defaultUploadActivityOptions,
   )
 where
 
-import Data.Default (Default, def)
 import Network.HTTP.Types (QueryLike, toQuery)
 import Strive.Enums (ActivityType)
 
@@ -19,16 +19,16 @@ data UploadActivityOptions = UploadActivityOptions
   }
   deriving (Show)
 
-instance Default UploadActivityOptions where
-  def =
-    UploadActivityOptions
-      { uploadActivityOptions_activityType = Nothing,
-        uploadActivityOptions_name = Nothing,
-        uploadActivityOptions_description = Nothing,
-        uploadActivityOptions_private = False,
-        uploadActivityOptions_trainer = False,
-        uploadActivityOptions_externalId = Nothing
-      }
+defaultUploadActivityOptions :: UploadActivityOptions
+defaultUploadActivityOptions =
+  UploadActivityOptions
+    { uploadActivityOptions_activityType = Nothing,
+      uploadActivityOptions_name = Nothing,
+      uploadActivityOptions_description = Nothing,
+      uploadActivityOptions_private = False,
+      uploadActivityOptions_trainer = False,
+      uploadActivityOptions_externalId = Nothing
+    }
 
 instance QueryLike UploadActivityOptions where
   toQuery options =

--- a/source/library/Strive/Utilities.hs
+++ b/source/library/Strive/Utilities.hs
@@ -1,6 +1,8 @@
 -- | Utility functions for making common actions easier.
 module Strive.Utilities
-  ( -- * Streams
+  ( with,
+
+    -- * Streams
     altitudeStream,
     cadenceStream,
     distanceStream,
@@ -20,6 +22,10 @@ import Data.Maybe (mapMaybe)
 import Data.Text (pack)
 import qualified Strive.Enums as Enums
 import Strive.Types (StreamDetailed, streamDetailed_data, streamDetailed_type)
+
+-- | Modify an action's default options by listing changes to it.
+with :: (Monoid a) => [a -> a] -> a
+with = foldr ($) mempty
 
 altitudeStream :: StreamDetailed -> Maybe [Double]
 altitudeStream = lookupStream Enums.AltitudeStream

--- a/source/library/Strive/Utilities.hs
+++ b/source/library/Strive/Utilities.hs
@@ -1,8 +1,6 @@
 -- | Utility functions for making common actions easier.
 module Strive.Utilities
-  ( with,
-
-    -- * Streams
+  ( -- * Streams
     altitudeStream,
     cadenceStream,
     distanceStream,
@@ -18,15 +16,10 @@ module Strive.Utilities
 where
 
 import Data.Aeson (FromJSON, Result (Error, Success), Value, fromJSON)
-import Data.Default (Default, def)
 import Data.Maybe (mapMaybe)
 import Data.Text (pack)
 import qualified Strive.Enums as Enums
 import Strive.Types (StreamDetailed, streamDetailed_data, streamDetailed_type)
-
--- | Modify an action's default options by listing changes to it.
-with :: (Default a) => [a -> a] -> a
-with = foldr ($) def
 
 altitudeStream :: StreamDetailed -> Maybe [Double]
 altitudeStream = lookupStream Enums.AltitudeStream

--- a/strive.cabal
+++ b/strive.cabal
@@ -26,7 +26,6 @@ common library
   build-depends:
     aeson ^>=2.1.2.1 || ^>=2.2.2.0,
     bytestring ^>=0.11.4.0 || ^>=0.12.0.2,
-    data-default ^>=0.7.1.1 || ^>=0.8.0.0,
     gpolyline ^>=0.1.0.1,
     http-client ^>=0.7.17,
     http-client-tls ^>=0.3.6.3,


### PR DESCRIPTION
I had this old branch sitting around. It might be nice to avoid using `data-default` in favor of just using the `Last` semigroup. 